### PR TITLE
Add WebSocket support and planning doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A modern, full-stack golf scoring app for the Wolf game and more, built with Vue
 - **Authentication**: Auth0 integration for secure login.
 - **Cloud-Ready**: Deploy frontend to Netlify, backend to Render, and use managed PostgreSQL.
 - **Newsletter Script**: Send beautiful HTML golf newsletters via Gmail.
+- **Real-time Updates**: WebSocket endpoint broadcasts live game changes.
 - **Thorough Documentation**: All code and APIs are documented for clarity and learning.
 
 ---

--- a/app/backend/README.md
+++ b/app/backend/README.md
@@ -30,6 +30,11 @@ This is the backend service for the Golf App, built with FastAPI.
 - Stripe will be used for secure payment processing.
 - Payment logic will be modular and PCI-compliant, with no raw card data handled by the backend.
 
+## Real-time WebSocket Updates
+FastAPI now exposes a `/ws/games/{game_id}` endpoint that allows clients to
+subscribe to live game changes. The `ConnectionManager` class manages
+connections per game and broadcasts JSON messages to all players.
+
 ## Database (MySQL)
 - MySQL will be used to persist user, game, and statistics data.
 - FastAPI will serve as the backend API between the UI and the database.
@@ -39,4 +44,5 @@ This is the backend service for the Golf App, built with FastAPI.
 
 ## Project Structure
 - `main.py`: FastAPI entrypoint
+- `websocket_manager.py`: In-memory connection manager for WebSocket clients
 - More modules to be added as the project grows

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -695,3 +695,20 @@ def check_and_unlock_achievements(user_id: int, game_id: int):
     finally:
         cursor.close()
         db.close()
+
+# WebSocket endpoint for real-time game updates
+from websocket_manager import ConnectionManager
+from fastapi import WebSocket
+
+manager = ConnectionManager()
+
+@app.websocket("/ws/games/{game_id}")
+async def game_updates(websocket: WebSocket, game_id: int):
+    await manager.connect(game_id, websocket)
+    try:
+        while True:
+            data = await websocket.receive_json()
+            await manager.broadcast(game_id, data)
+    except WebSocketDisconnect:
+        manager.disconnect(game_id, websocket)
+

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -5,3 +5,4 @@ pydantic[email]
 python-dotenv
 psycopg2-binary
 psycopg2
+websockets

--- a/app/backend/websocket_manager.py
+++ b/app/backend/websocket_manager.py
@@ -1,0 +1,24 @@
+from typing import Dict, List
+from fastapi import WebSocket
+
+
+class ConnectionManager:
+    """Manages WebSocket connections per game."""
+
+    def __init__(self) -> None:
+        self.active_connections: Dict[int, List[WebSocket]] = {}
+
+    async def connect(self, game_id: int, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.setdefault(game_id, []).append(websocket)
+
+    def disconnect(self, game_id: int, websocket: WebSocket) -> None:
+        if game_id in self.active_connections:
+            if websocket in self.active_connections[game_id]:
+                self.active_connections[game_id].remove(websocket)
+            if not self.active_connections[game_id]:
+                del self.active_connections[game_id]
+
+    async def broadcast(self, game_id: int, message: dict) -> None:
+        for connection in self.active_connections.get(game_id, []):
+            await connection.send_json(message)

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1,0 +1,35 @@
+# Planned Enhancements
+
+This document tracks proposed GitHub issues to expand the project.
+
+## 1. Real-time Collaboration
+- Implement WebSocket support in FastAPI for live score updates.
+- Create a simple in-memory broadcaster to distribute messages to all connected clients of a game.
+- Update frontend to connect via WebSocket and reflect live changes.
+
+## 2. AI-driven Insights and Personalization
+- Analyze player scores to generate strategy tips.
+- Add backend endpoint that produces summary stats and recommendations.
+- Integrate with the newsletter script for personalized weekly updates.
+
+## 3. Expand Game Types and Leaderboards
+- Add modules for stroke play, match play, Stableford and Ryder Cup.
+- Extend leaderboard logic to handle multiple game types and new stats (birdies, pars, handicap improvement).
+
+## 4. Backend Architecture Improvements
+- Migrate from raw SQL to SQLAlchemy ORM for safer queries and relationships.
+- Evaluate async database drivers for scalability.
+
+## 5. Enhanced Testing and CI/CD
+- Add unit tests for API routes and Vue components.
+- Integrate GitHub Actions to run tests and linting on every push.
+
+## 6. Security and Compliance
+- Implement rate limiting and CSRF protection.
+- Plan modular payment processing for future side bets with PCI compliance in mind.
+
+## 7. Polished User Experience
+- Improve dark-mode styles and responsive layouts.
+- Add offline-first capabilities with service workers.
+- Perform accessibility audits and address issues.
+


### PR DESCRIPTION
## Summary
- outline future development tasks in `docs/ISSUES.md`
- add a `ConnectionManager` for WebSocket connections
- expose `/ws/games/{game_id}` WebSocket endpoint
- document real-time updates in READMEs
- include `websockets` in backend requirements

## Testing
- `npm test -- --list` *(fails: Error: write EPIPE)*

------
https://chatgpt.com/codex/tasks/task_e_688b92c681908320a0a40139bf09162b